### PR TITLE
Document Linux CLI publish flow and add helper script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Guidelines
+
+This repository maintains an incremental plan for delivering Linux support for the OpenIPC Configurator. Follow these instructions when making changes anywhere in this repo.
+
+## Planning & Documentation
+- Before implementing new functionality, review the living plan in `docs/linux-support-plan.md`.
+- Update the plan whenever scope, milestones, or validation status change.
+- Keep the README aligned with the implemented feature set; document any new Linux workflows or limitations.
+
+## Implementation Priorities
+1. Preserve compatibility with the existing Windows WinForms workflow while growing cross-platform support through the CLI.
+2. Reuse the shared configuration artifacts (`settings.conf`, presets, shell scripts) so Windows and Linux users remain in sync.
+3. Prefer managed implementations (SSH.NET, .NET APIs) over shelling out to Windows-only tooling.
+
+## Validation Requirements
+- Run and report the following commands after code changes that affect .NET projects:
+  - `dotnet build OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj -c Release`
+  - `dotnet test OpenIPCConfigurator.Cli.Tests/OpenIPCConfigurator.Cli.Tests.csproj`
+  - `./publish-linux-cli.sh` when publishing artifacts is relevant.
+- Capture additional commands in the plan’s validation log as they are executed.
+
+## Coding Conventions
+- Use idiomatic .NET 8 patterns (nullable reference types enabled, async APIs where appropriate).
+- Keep new C# source files inside the `OpenIPCConfigurator.Cli` namespace and mirror the existing project structure.
+- Favor descriptive logging and avoid leaking secrets; never log passwords by default.
+
+## Coordination Checklist
+- Ensure new work maintains parity with the legacy `Extern.bat` verbs listed in the plan.
+- Note any deferred tasks in the "Future enhancements" section of the plan so they can be prioritized later.
+- When touching shared assets (presets, shell scripts), verify they remain executable on both Windows (CRLF) and Linux (LF) as appropriate.
+

--- a/OpenIPC Configurator.sln
+++ b/OpenIPC Configurator.sln
@@ -5,16 +5,28 @@ VisualStudioVersion = 17.9.34701.34
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "OpenIPC Configurator", "OpenIPC Configurator.vbproj", "{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenIPCConfigurator.Cli", "OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj", "{684DB443-8EF2-498F-B826-B80EFF55A784}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenIPCConfigurator.Cli.Tests", "OpenIPCConfigurator.Cli.Tests/OpenIPCConfigurator.Cli.Tests.csproj", "{A4DF49A3-3169-4918-98EE-BF3E94CC2B24}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}.Release|Any CPU.Build.0 = Release|Any CPU
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{D23EA7C6-0FFE-443B-AB1B-1383FDDD0483}.Release|Any CPU.Build.0 = Release|Any CPU
+{684DB443-8EF2-498F-B826-B80EFF55A784}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{684DB443-8EF2-498F-B826-B80EFF55A784}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{684DB443-8EF2-498F-B826-B80EFF55A784}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{684DB443-8EF2-498F-B826-B80EFF55A784}.Release|Any CPU.Build.0 = Release|Any CPU
+{A4DF49A3-3169-4918-98EE-BF3E94CC2B24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A4DF49A3-3169-4918-98EE-BF3E94CC2B24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A4DF49A3-3169-4918-98EE-BF3E94CC2B24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A4DF49A3-3169-4918-98EE-BF3E94CC2B24}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenIPCConfigurator.Cli.Tests/CommandLineParserTests.cs
+++ b/OpenIPCConfigurator.Cli.Tests/CommandLineParserTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using OpenIPCConfigurator.Cli;
+using Xunit;
+
+namespace OpenIPCConfigurator.Cli.Tests;
+
+public class CommandLineParserTests
+{
+    [Fact]
+    public void TryParse_ReturnsOptions_WithMinimalArguments()
+    {
+        var args = new[] { "--ip", "192.168.0.2", "--password", "secret" };
+
+        var result = CommandLineParser.TryParse(args, out var options, out var error);
+
+        Assert.True(result);
+        Assert.Null(error);
+        Assert.NotNull(options);
+        Assert.Equal("openipc", options!.DeviceKey);
+        Assert.Equal("192.168.0.2", options.IpAddress);
+        Assert.Equal("secret", options.Password);
+        Assert.Equal(22, options.Port);
+    }
+
+    [Fact]
+    public void TryParse_ReadsIpFromSettings_WhenMissing()
+    {
+        using var temp = new TempDirectory();
+        var settingsPath = Path.Combine(temp.Path, "settings.conf");
+        File.WriteAllLines(settingsPath, new[]
+        {
+            "openipc:10.0.0.5",
+            "nvr:",
+            "radxa:"
+        });
+
+        var args = new[]
+        {
+            "--password", "pw",
+            "--workdir", temp.Path
+        };
+
+        var result = CommandLineParser.TryParse(args, out var options, out var error);
+
+        Assert.True(result);
+        Assert.Null(error);
+        Assert.NotNull(options);
+        Assert.Equal("10.0.0.5", options!.IpAddress);
+        Assert.Equal(Path.Combine(temp.Path, "settings.conf"), options.SettingsPath);
+    }
+
+    [Fact]
+    public void TryParse_ReturnsFalse_ForInvalidPort()
+    {
+        var args = new[] { "--ip", "192.168.0.2", "--password", "secret", "--port", "invalid" };
+
+        var result = CommandLineParser.TryParse(args, out var options, out var error);
+
+        Assert.False(result);
+        Assert.Null(options);
+        Assert.Equal("Invalid SSH port 'invalid'.", error);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "openipc-cli-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup failures in tests.
+            }
+        }
+    }
+}

--- a/OpenIPCConfigurator.Cli.Tests/OpenIPCConfigurator.Cli.Tests.csproj
+++ b/OpenIPCConfigurator.Cli.Tests/OpenIPCConfigurator.Cli.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenIPCConfigurator.Cli\OpenIPCConfigurator.Cli.csproj" />
+  </ItemGroup>
+</Project>

--- a/OpenIPCConfigurator.Cli/AssemblyInfo.cs
+++ b/OpenIPCConfigurator.Cli/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpenIPCConfigurator.Cli.Tests")]

--- a/OpenIPCConfigurator.Cli/CommandLineParser.cs
+++ b/OpenIPCConfigurator.Cli/CommandLineParser.cs
@@ -1,0 +1,213 @@
+using System.Globalization;
+
+namespace OpenIPCConfigurator.Cli;
+
+internal static class CommandLineParser
+{
+    private static readonly HashSet<string> BooleanTrueValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "true", "1", "yes", "y", "on"
+    };
+
+    private static readonly HashSet<string> BooleanFalseValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "false", "0", "no", "n", "off"
+    };
+
+    private const string DefaultSettingsFileName = "settings.conf";
+
+    public static bool TryParse(string[] args, out CommandOptions? options, out string? errorMessage)
+    {
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < args.Length; i++)
+        {
+            var token = args[i];
+            if (token == "--")
+            {
+                // Ignore everything after "--" for now.
+                continue;
+            }
+
+            if (!token.StartsWith('-'))
+            {
+                errorMessage = $"Unexpected argument '{token}'.";
+                options = null;
+                return false;
+            }
+
+            string key;
+            if (token.StartsWith("--"))
+            {
+                key = token[2..];
+            }
+            else
+            {
+                key = token.Length switch
+                {
+                    2 => token[1] switch
+                    {
+                        'i' => "ip",
+                        'p' => "password",
+                        'd' => "device",
+                        'u' => "username",
+                        'P' => "port",
+                        'w' => "workdir",
+                        'o' => "output",
+                        'I' => "input",
+                        'r' => "reboot",
+                        _ => null!
+                    },
+                    _ => null!
+                } ?? throw new ArgumentException($"Unknown option '{token}'.");
+            }
+
+            string? value = null;
+            var expectsValue = !IsFlag(key);
+            if (expectsValue && i + 1 < args.Length && !args[i + 1].StartsWith('-'))
+            {
+                value = args[++i];
+            }
+            else if (expectsValue)
+            {
+                errorMessage = $"Option '{token}' requires a value.";
+                options = null;
+                return false;
+            }
+            else if (value is null)
+            {
+                value = "true";
+            }
+
+            values[key] = value;
+        }
+
+        var deviceKey = values.TryGetValue("device", out var deviceRaw) && !string.IsNullOrWhiteSpace(deviceRaw)
+            ? deviceRaw!
+            : "openipc";
+
+        var useYaml = GetBoolean(values, "yaml") ?? false;
+        DeviceProfile profile;
+        try
+        {
+            profile = DeviceRegistry.GetProfile(deviceKey, useYaml);
+            deviceKey = profile.Key; // Normalise the key.
+        }
+        catch (ArgumentException ex)
+        {
+            errorMessage = ex.Message;
+            options = null;
+            return false;
+        }
+
+        var workDirectory = values.TryGetValue("workdir", out var workRaw) && !string.IsNullOrWhiteSpace(workRaw)
+            ? Path.GetFullPath(workRaw!)
+            : Directory.GetCurrentDirectory();
+
+        var settingsPath = values.TryGetValue("settings", out var settingsRaw) && !string.IsNullOrWhiteSpace(settingsRaw)
+            ? settingsRaw!
+            : Path.Combine(workDirectory, DefaultSettingsFileName);
+        if (!Path.IsPathRooted(settingsPath))
+        {
+            settingsPath = Path.GetFullPath(Path.Combine(workDirectory, settingsPath));
+        }
+
+        SettingsStore? settings = null;
+        if (File.Exists(settingsPath) || !values.ContainsKey("ip"))
+        {
+            settings = SettingsStore.Load(settingsPath);
+        }
+
+        var ipAddress = values.TryGetValue("ip", out var ipRaw) && !string.IsNullOrWhiteSpace(ipRaw)
+            ? ipRaw!
+            : settings?.TryGetAddress(deviceKey);
+        if (string.IsNullOrWhiteSpace(ipAddress))
+        {
+            errorMessage = "An IP address must be provided via --ip or stored in settings.conf.";
+            options = null;
+            return false;
+        }
+
+        var username = values.TryGetValue("username", out var userRaw) && !string.IsNullOrWhiteSpace(userRaw)
+            ? userRaw!
+            : "root";
+
+        if (!values.TryGetValue("password", out var password) || string.IsNullOrWhiteSpace(password))
+        {
+            errorMessage = "A password must be provided with --password.";
+            options = null;
+            return false;
+        }
+
+        var port = 22;
+        if (values.TryGetValue("port", out var portRaw))
+        {
+            if (!int.TryParse(portRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out port))
+            {
+                errorMessage = $"Invalid SSH port '{portRaw}'.";
+                options = null;
+                return false;
+            }
+        }
+
+        var rememberSettings = GetBoolean(values, "remember") ?? true;
+        if (GetBoolean(values, "no-remember") == true)
+        {
+            rememberSettings = false;
+        }
+
+        var triggerReboot = GetBoolean(values, "reboot") ?? false;
+
+        var downloadDirectory = values.TryGetValue("output", out var outputRaw) && !string.IsNullOrWhiteSpace(outputRaw)
+            ? Path.GetFullPath(Path.Combine(workDirectory, outputRaw!))
+            : workDirectory;
+
+        var uploadDirectory = values.TryGetValue("input", out var inputRaw) && !string.IsNullOrWhiteSpace(inputRaw)
+            ? Path.GetFullPath(Path.Combine(workDirectory, inputRaw!))
+            : workDirectory;
+
+        options = new CommandOptions(
+            deviceKey.ToLowerInvariant(),
+            ipAddress!,
+            username,
+            password!,
+            port,
+            workDirectory,
+            downloadDirectory,
+            uploadDirectory,
+            settingsPath,
+            rememberSettings,
+            useYaml,
+            triggerReboot);
+        errorMessage = null;
+        return true;
+    }
+
+    private static bool IsFlag(string key) => key switch
+    {
+        "yaml" => true,
+        "remember" => true,
+        "no-remember" => true,
+        "reboot" => true,
+        _ => false
+    };
+
+    private static bool? GetBoolean(IReadOnlyDictionary<string, string?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var raw) || raw is null)
+        {
+            return null;
+        }
+
+        if (BooleanTrueValues.Contains(raw))
+        {
+            return true;
+        }
+
+        if (BooleanFalseValues.Contains(raw))
+        {
+            return false;
+        }
+
+        return null;
+    }
+}

--- a/OpenIPCConfigurator.Cli/CommandOptions.cs
+++ b/OpenIPCConfigurator.Cli/CommandOptions.cs
@@ -1,0 +1,56 @@
+namespace OpenIPCConfigurator.Cli;
+
+internal sealed class CommandOptions
+{
+    public CommandOptions(
+        string deviceKey,
+        string ipAddress,
+        string username,
+        string password,
+        int port,
+        string workDirectory,
+        string downloadDirectory,
+        string uploadDirectory,
+        string settingsPath,
+        bool rememberSettings,
+        bool useYaml,
+        bool triggerReboot)
+    {
+        DeviceKey = deviceKey;
+        IpAddress = ipAddress;
+        Username = username;
+        Password = password;
+        Port = port;
+        WorkDirectory = workDirectory;
+        DownloadDirectory = downloadDirectory;
+        UploadDirectory = uploadDirectory;
+        SettingsPath = settingsPath;
+        RememberSettings = rememberSettings;
+        UseYaml = useYaml;
+        TriggerReboot = triggerReboot;
+    }
+
+    public string DeviceKey { get; }
+
+    public string IpAddress { get; }
+
+    public string Username { get; }
+
+    public string Password { get; }
+
+    public int Port { get; }
+
+    public string WorkDirectory { get; }
+
+    public string DownloadDirectory { get; }
+
+    public string UploadDirectory { get; }
+
+    public string SettingsPath { get; }
+
+    public bool RememberSettings { get; }
+
+    public bool UseYaml { get; }
+
+    public bool TriggerReboot { get; }
+}

--- a/OpenIPCConfigurator.Cli/DeviceProfile.cs
+++ b/OpenIPCConfigurator.Cli/DeviceProfile.cs
@@ -1,0 +1,39 @@
+namespace OpenIPCConfigurator.Cli;
+
+/// <summary>
+/// Describes the files and post-processing actions associated with a supported device role.
+/// </summary>
+internal sealed class DeviceProfile
+{
+    public DeviceProfile(
+        string key,
+        string description,
+        IReadOnlyList<FileTransfer> transfers,
+        IReadOnlyList<string> postUploadCommands)
+    {
+        Key = key;
+        Description = description;
+        Transfers = transfers;
+        PostUploadCommands = postUploadCommands;
+    }
+
+    /// <summary>
+    /// Canonical key used in settings.conf (e.g. "openipc").
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// Human readable description used in help text.
+    /// </summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// Files to download/upload for this profile.
+    /// </summary>
+    public IReadOnlyList<FileTransfer> Transfers { get; }
+
+    /// <summary>
+    /// Commands executed after uploading configuration files.
+    /// </summary>
+    public IReadOnlyList<string> PostUploadCommands { get; }
+}

--- a/OpenIPCConfigurator.Cli/DeviceRegistry.cs
+++ b/OpenIPCConfigurator.Cli/DeviceRegistry.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenIPCConfigurator.Cli;
+
+internal static class DeviceRegistry
+{
+    private static readonly DeviceProfile OpenIpcProfile = new(
+        key: "openipc",
+        description: "OpenIPC FPV camera (wfb.conf format)",
+        transfers: new List<FileTransfer>
+        {
+            new("/etc/majestic.yaml", "majestic.yaml"),
+            new("/etc/wfb.conf", "wfb.conf"),
+            new("/etc/telemetry.conf", "telemetry.conf")
+        },
+        postUploadCommands: new List<string>
+        {
+            "dos2unix /etc/wfb.conf /etc/telemetry.conf /etc/majestic.yaml"
+        });
+
+    private static readonly DeviceProfile OpenIpcYamlProfile = new(
+        key: "openipc",
+        description: "OpenIPC FPV camera (wfb.yaml format)",
+        transfers: new List<FileTransfer>
+        {
+            new("/etc/majestic.yaml", "majestic.yaml"),
+            new("/etc/wfb.yaml", "wfb.yaml")
+        },
+        postUploadCommands: new List<string>
+        {
+            "dos2unix /etc/wfb.yaml /etc/majestic.yaml"
+        });
+
+    private static readonly DeviceProfile NvrProfile = new(
+        key: "nvr",
+        description: "Ground station / NVR receiver",
+        transfers: new List<FileTransfer>
+        {
+            new("/etc/vdec.conf", "vdec.conf"),
+            new("/etc/wfb.conf", "wfb.conf"),
+            new("/etc/telemetry.conf", "telemetry.conf")
+        },
+        postUploadCommands: new List<string>
+        {
+            "dos2unix /etc/wfb.conf /etc/telemetry.conf /etc/vdec.conf"
+        });
+
+    private static readonly DeviceProfile RadxaProfile = new(
+        key: "radxa",
+        description: "Radxa Zero 3W controller",
+        transfers: new List<FileTransfer>
+        {
+            new("/etc/wifibroadcast.cfg", "wifibroadcast.cfg"),
+            new("/etc/modprobe.d/wfb.conf", "wfb.conf"),
+            new("/config/scripts/screen-mode", "screen-mode"),
+            new("/etc/default/wifibroadcast", "wifibroadcast")
+        },
+        postUploadCommands: new List<string>
+        {
+            "dos2unix /etc/wifibroadcast.cfg /etc/modprobe.d/wfb.conf /config/scripts/screen-mode /etc/default/wifibroadcast"
+        });
+
+    public static DeviceProfile GetProfile(string deviceKey, bool useYaml)
+    {
+        return NormalizeKey(deviceKey) switch
+        {
+            "openipc" => useYaml ? OpenIpcYamlProfile : OpenIpcProfile,
+            "nvr" => NvrProfile,
+            "radxa" => RadxaProfile,
+            _ => throw new ArgumentException($"Unknown device '{deviceKey}'. Supported values: {string.Join(", ", GetSupportedDeviceKeys())}.")
+        };
+    }
+
+    public static IEnumerable<(string Key, string Description)> GetSupportedDevices()
+    {
+        yield return (OpenIpcProfile.Key, OpenIpcProfile.Description);
+        yield return (NvrProfile.Key, NvrProfile.Description);
+        yield return (RadxaProfile.Key, RadxaProfile.Description);
+    }
+
+    private static IEnumerable<string> GetSupportedDeviceKeys() => GetSupportedDevices().Select(device => device.Key);
+
+    private static string NormalizeKey(string deviceKey)
+    {
+        return deviceKey.ToLowerInvariant() switch
+        {
+            "openipc" or "camera" or "cam" => "openipc",
+            "nvr" or "vrx" or "receiver" => "nvr",
+            "radxa" or "radxazero3w" or "radxa-zero-3w" => "radxa",
+            _ => deviceKey.ToLowerInvariant()
+        };
+    }
+}

--- a/OpenIPCConfigurator.Cli/FileTransfer.cs
+++ b/OpenIPCConfigurator.Cli/FileTransfer.cs
@@ -1,0 +1,8 @@
+namespace OpenIPCConfigurator.Cli;
+
+/// <summary>
+/// Represents a single file that should be transferred between the host and a remote device.
+/// </summary>
+/// <param name="RemotePath">Absolute path of the file on the remote device.</param>
+/// <param name="LocalName">File name to use on the local filesystem.</param>
+internal sealed record FileTransfer(string RemotePath, string LocalName);

--- a/OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj
+++ b/OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SSH.NET" Version="2024.2.0" />
+  </ItemGroup>
+</Project>

--- a/OpenIPCConfigurator.Cli/Program.cs
+++ b/OpenIPCConfigurator.Cli/Program.cs
@@ -1,0 +1,171 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace OpenIPCConfigurator.Cli;
+
+internal static class Program
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            PrintUsage();
+            return 1;
+        }
+
+        var command = args[0].ToLowerInvariant();
+        if (command is "help" or "-h" or "--help")
+        {
+            PrintUsage();
+            return 0;
+        }
+
+        var commandArgs = args.Skip(1).ToArray();
+        if (commandArgs.Any(arg => arg is "-h" or "--help"))
+        {
+            PrintUsage(command);
+            return 0;
+        }
+
+        if (!CommandLineParser.TryParse(commandArgs, out var options, out var error))
+        {
+            Console.Error.WriteLine(error);
+            return 1;
+        }
+
+        try
+        {
+            return command switch
+            {
+                "download" => RunDownload(options!),
+                "upload" => RunUpload(options!),
+                "reboot" => RunReboot(options!),
+                _ => UnknownCommand(command)
+            };
+        }
+        catch (FileNotFoundException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            if (ex.InnerException is not null)
+            {
+                Console.Error.WriteLine($"Inner exception: {ex.InnerException.Message}");
+            }
+
+            return 1;
+        }
+    }
+
+    private static int RunDownload(CommandOptions options)
+    {
+        var profile = DeviceRegistry.GetProfile(options.DeviceKey, options.UseYaml);
+        var destination = options.DownloadDirectory;
+        Console.WriteLine($"Downloading configuration from {options.IpAddress} ({profile.Description}) to '{destination}'.");
+
+        using var session = new SshSession(options.IpAddress, options.Port, options.Username, options.Password);
+        session.DownloadFiles(profile.Transfers, destination);
+
+        Console.WriteLine("Download complete.");
+
+        PersistSettings(options, profile);
+        return 0;
+    }
+
+    private static int RunUpload(CommandOptions options)
+    {
+        var profile = DeviceRegistry.GetProfile(options.DeviceKey, options.UseYaml);
+        Console.WriteLine($"Uploading configuration from '{options.UploadDirectory}' to {options.IpAddress} ({profile.Description}).");
+
+        using var session = new SshSession(options.IpAddress, options.Port, options.Username, options.Password);
+        session.UploadFiles(profile.Transfers, options.UploadDirectory);
+        session.ExecuteCommands(profile.PostUploadCommands);
+
+        if (options.TriggerReboot)
+        {
+            Console.WriteLine("Issuing reboot command.");
+            session.ExecuteCommands(new[] { "reboot" });
+        }
+
+        Console.WriteLine("Upload complete.");
+
+        PersistSettings(options, profile);
+        return 0;
+    }
+
+    private static int RunReboot(CommandOptions options)
+    {
+        var profile = DeviceRegistry.GetProfile(options.DeviceKey, options.UseYaml);
+        Console.WriteLine($"Sending reboot command to {options.IpAddress} ({profile.Description}).");
+
+        using var session = new SshSession(options.IpAddress, options.Port, options.Username, options.Password);
+        session.ExecuteCommands(new[] { "reboot" });
+
+        PersistSettings(options, profile);
+        return 0;
+    }
+
+    private static void PersistSettings(CommandOptions options, DeviceProfile profile)
+    {
+        if (!options.RememberSettings)
+        {
+            return;
+        }
+
+        var store = SettingsStore.Load(options.SettingsPath);
+        store.SetAddress(profile.Key, options.IpAddress);
+        store.Save();
+        Console.WriteLine($"Updated '{options.SettingsPath}' with the last-used {profile.Key} address.");
+    }
+
+    private static void PrintUsage(string? command = null)
+    {
+        Console.WriteLine("OpenIPC Configurator CLI");
+        Console.WriteLine();
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  configurator-cli <command> [options]");
+        Console.WriteLine();
+        Console.WriteLine("Commands:");
+        Console.WriteLine("  download   Download configuration files from a device.");
+        Console.WriteLine("  upload     Upload configuration files to a device.");
+        Console.WriteLine("  reboot     Issue a reboot over SSH.");
+        Console.WriteLine("  help       Show this help message.");
+        Console.WriteLine();
+        Console.WriteLine("Common options:");
+        Console.WriteLine("  --ip, -i <address>          Device IP address (falls back to settings.conf entry).\n" +
+                          "  --password, -p <password>   SSH password (required).\n" +
+                          "  --device, -d <name>         Device type (default: openipc).\n" +
+                          "  --username, -u <name>       SSH username (default: root).\n" +
+                          "  --port, -P <number>         SSH port (default: 22).\n" +
+                          "  --workdir, -w <path>        Working directory (default: current).\n" +
+                          "  --input, -I <path>          Override upload source directory.\n" +
+                          "  --output, -o <path>         Override download destination directory.\n" +
+                          "  --settings <path>           Path to settings.conf (default: <workdir>/settings.conf).\n" +
+                          "  --yaml                      Use the wfb.yaml profile for OpenIPC cameras.\n" +
+                          "  --reboot, -r                Reboot the device after uploading.\n" +
+                          "  --no-remember               Do not update settings.conf after completion.");
+        Console.WriteLine();
+        Console.WriteLine("Supported devices:");
+        foreach (var device in DeviceRegistry.GetSupportedDevices())
+        {
+            Console.WriteLine($"  {device.Key,-8} {device.Description}");
+        }
+        Console.WriteLine();
+
+        if (!string.IsNullOrEmpty(command))
+        {
+            Console.WriteLine($"Command '{command}' accepts the options listed above.");
+            Console.WriteLine();
+        }
+    }
+
+    private static int UnknownCommand(string command)
+    {
+        Console.Error.WriteLine($"Unknown command '{command}'. Use 'help' to list available commands.");
+        return 1;
+    }
+}

--- a/OpenIPCConfigurator.Cli/SettingsStore.cs
+++ b/OpenIPCConfigurator.Cli/SettingsStore.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenIPCConfigurator.Cli;
+
+internal sealed class SettingsStore
+{
+    private static readonly string[] DefaultKeys = { "openipc", "nvr", "radxa" };
+
+    private readonly Dictionary<string, string> _values;
+    private readonly string _path;
+
+    private SettingsStore(string path, Dictionary<string, string> values)
+    {
+        _path = path;
+        _values = values;
+    }
+
+    public static SettingsStore Load(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("The settings path cannot be empty.", nameof(path));
+        }
+
+        var resolvedPath = Path.GetFullPath(path);
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (File.Exists(resolvedPath))
+        {
+            foreach (var line in File.ReadLines(resolvedPath))
+            {
+                if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var parts = line.Split(':', 2);
+                if (parts.Length == 2)
+                {
+                    values[parts[0].Trim()] = parts[1].Trim();
+                }
+            }
+        }
+        else
+        {
+            foreach (var key in DefaultKeys)
+            {
+                values[key] = "192.168.0.1";
+            }
+        }
+
+        return new SettingsStore(resolvedPath, values);
+    }
+
+    public string? TryGetAddress(string key)
+    {
+        if (!_values.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
+    }
+
+    public void SetAddress(string key, string ipAddress)
+    {
+        _values[key] = ipAddress;
+    }
+
+    public void Save()
+    {
+        var directory = Path.GetDirectoryName(_path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var lines = new List<string>();
+        foreach (var key in DefaultKeys)
+        {
+            if (_values.TryGetValue(key, out var value))
+            {
+                lines.Add($"{key}:{value}");
+            }
+            else
+            {
+                lines.Add($"{key}:");
+            }
+        }
+
+        foreach (var extra in _values)
+        {
+            if (DefaultKeys.Contains(extra.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            lines.Add($"{extra.Key}:{extra.Value}");
+        }
+
+        File.WriteAllLines(_path, lines);
+    }
+}

--- a/OpenIPCConfigurator.Cli/SshSession.cs
+++ b/OpenIPCConfigurator.Cli/SshSession.cs
@@ -1,0 +1,95 @@
+using Renci.SshNet;
+
+namespace OpenIPCConfigurator.Cli;
+
+internal sealed class SshSession : IDisposable
+{
+    private readonly SshClient _sshClient;
+    private readonly ScpClient _scpClient;
+    private bool _isConnected;
+
+    public SshSession(string host, int port, string username, string password)
+    {
+        var connectionInfo = new PasswordConnectionInfo(host, port, username, password);
+        _sshClient = new SshClient(connectionInfo);
+        _scpClient = new ScpClient(connectionInfo);
+    }
+
+    public void Connect()
+    {
+        if (_isConnected)
+        {
+            return;
+        }
+
+        _sshClient.Connect();
+        _scpClient.Connect();
+        _isConnected = true;
+    }
+
+    public void DownloadFiles(IEnumerable<FileTransfer> transfers, string destinationDirectory)
+    {
+        Connect();
+        Directory.CreateDirectory(destinationDirectory);
+
+        foreach (var transfer in transfers)
+        {
+            var localPath = Path.Combine(destinationDirectory, transfer.LocalName);
+            using var localStream = File.Create(localPath);
+            _scpClient.Download(transfer.RemotePath, localStream);
+        }
+    }
+
+    public void UploadFiles(IEnumerable<FileTransfer> transfers, string sourceDirectory)
+    {
+        Connect();
+
+        foreach (var transfer in transfers)
+        {
+            var localPath = Path.Combine(sourceDirectory, transfer.LocalName);
+            if (!File.Exists(localPath))
+            {
+                throw new FileNotFoundException($"Required file '{transfer.LocalName}' not found in '{sourceDirectory}'.", localPath);
+            }
+
+            using var localStream = File.OpenRead(localPath);
+            _scpClient.Upload(localStream, transfer.RemotePath);
+        }
+    }
+
+    public void ExecuteCommands(IEnumerable<string> commands)
+    {
+        Connect();
+
+        foreach (var command in commands)
+        {
+            if (string.IsNullOrWhiteSpace(command))
+            {
+                continue;
+            }
+
+            using var cmd = _sshClient.CreateCommand(command);
+            _ = cmd.Execute();
+            if (cmd.ExitStatus != 0)
+            {
+                throw new InvalidOperationException($"Command '{command}' failed with exit code {cmd.ExitStatus}: {cmd.Error}");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_scpClient.IsConnected)
+        {
+            _scpClient.Disconnect();
+        }
+
+        if (_sshClient.IsConnected)
+        {
+            _sshClient.Disconnect();
+        }
+
+        _scpClient.Dispose();
+        _sshClient.Dispose();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -24,3 +24,56 @@ Check the IP and network connection.
 ---
 
 [Manual setup](README-manual.md)
+
+---
+
+## Linux command line support
+
+The repository now ships a cross-platform CLI (`OpenIPCConfigurator.Cli`) that mirrors the common download/upload workflows
+without relying on Windows-only PuTTY tooling.
+
+### Prerequisites
+
+- .NET 8 SDK or runtime (`dotnet` executable) installed on your Linux host.
+- Network access to the OpenIPC device (default credentials remain `root` / device password).
+
+### Building the CLI
+
+From the repository root you can publish a Linux build with the helper script:
+
+```bash
+./publish-linux-cli.sh
+```
+
+The script wraps `dotnet publish` with the `linux-x64` runtime identifier and writes the output to `publish/linux/`.
+If you prefer to run the command manually, invoke:
+
+```bash
+dotnet publish OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj \
+  -c Release \
+  -r linux-x64 \
+  --self-contained false \
+  -o publish/linux
+```
+
+### Usage examples
+
+Download camera configuration:
+
+```bash
+dotnet run --project OpenIPCConfigurator.Cli -- download -i 192.168.0.10 -p op
+```
+
+Upload the edited files back to the camera and reboot afterwards:
+
+```bash
+dotnet run --project OpenIPCConfigurator.Cli -- upload -i 192.168.0.10 -p op --reboot
+```
+
+Key flags:
+
+- `--device` / `-d` – choose between `openipc`, `nvr`, or `radxa`.
+- `--yaml` – switch the OpenIPC profile to the YAML-based wireless stack (`wfb.yaml`).
+- `--no-remember` – skip updating `settings.conf` with the last-used IP address.
+
+For full option details run `dotnet run --project OpenIPCConfigurator.Cli -- help`.

--- a/docs/linux-support-plan.md
+++ b/docs/linux-support-plan.md
@@ -1,0 +1,66 @@
+# Linux Support Analysis and Plan
+
+## Codebase Overview
+- **Project type:** The repository currently ships a Visual Basic .NET 8 Windows Forms application (`OpenIPC Configurator.vbproj`). The UI logic in `Configurator.vb` drives user interactions and orchestrates device communication.
+- **External tooling:** Instead of using native .NET networking APIs, the UI shells out to `extern.bat`, a very large Windows batch file that wraps PuTTY's `pscp`/`plink` utilities to copy configuration files, reboot devices, and run maintenance commands.
+- **Configuration state:** A local `settings.conf` file stores the last-used IP addresses for different device roles (`openipc`, `nvr`, `radxa`). Numerous preset YAML/CFG files live alongside the executable and are assumed to be in the working directory.
+- **Platform coupling:**
+  - The WinForms project targets `net8.0-windows` and uses Windows-only UI components.
+  - Automation is delegated to a `.bat` script and PuTTY executables, tying the workflow to Windows.
+  - Several helper assets (resolution scripts, presets) are shell-friendly and can already run on Linux, but there is no orchestrator for them.
+
+## Linux Support Goals
+1. Allow users on Linux to download, edit, and upload the same configuration bundles without relying on PuTTY or Windows batch files.
+2. Preserve the existing workflow expectations (file names, settings persistence) so Windows and Linux users share the same artifacts.
+3. Create a foundation that can later be reused by the WinForms client to remove the PuTTY dependency altogether.
+
+## Proposed Approach
+### High-level strategy
+- Introduce a cross-platform .NET 8 CLI (`OpenIPCConfigurator.Cli`) that encapsulates SSH/SCP interactions using the managed [`SSH.NET`](https://github.com/sshnet/SSH.NET) library (surface namespace `Renci.SshNet`).
+- Model each supported device role (OpenIPC camera, NVR receiver, Radxa controller) as a profile that declares which remote files to transfer and which post-upload commands to execute (`dos2unix`, `reboot`, etc.).
+- Reuse the existing `settings.conf` format so the CLI can remember the last-used IP addresses per role and remain compatible with the Windows app.
+- Document how Linux users can invoke the CLI for download/upload/reboot operations.
+
+### Command parity snapshot
+The legacy `Extern.bat` script orchestrates PuTTY utilities for a wide range of actions. To keep scope manageable, phase 1 concentrates on the essential configuration lifecycle, while cataloguing the remaining tasks for follow-up work.
+
+| Script verb            | Purpose                                              | Phase 1 CLI parity             | Notes |
+|------------------------|------------------------------------------------------|-------------------------------|-------|
+| `dl`, `dlyaml`         | Download OpenIPC camera configs                      | ✅ `download` command          | YAML support controlled via `--yaml` switch. |
+| `ul`, `ulr`, `ulyamlr` | Upload OpenIPC configs (optional reboot)             | ✅ `upload` + `--reboot` flag  | CLI emits reboot only when requested. |
+| `dlvrx`, `ulvrx(r)`    | Ground-station config sync                           | ✅ `--device nvr` profile      | Same transfers and `dos2unix` calls. |
+| `dlwfbng`, `ulwfbng(r)`| Radxa controller config sync                         | ✅ `--device radxa` profile    | Upload ensures required files exist. |
+| `rb`                   | Remote reboot                                        | ✅ dedicated `reboot` command  | Aligns with GUI reboot button flow. |
+| Remaining verbs (keys, UART, firmware, extras, etc.) | Maintenance & advanced tweaks | ⏳ Future iterations | Documented under "Future enhancements" backlog. |
+
+### Implementation plan (phase 1 – executed now)
+1. **Create documentation** (this file) to capture the current architecture and Linux-support strategy.
+2. **Add the CLI project** targeting `net8.0`, reference `SSH.NET`, and wire it into the existing solution for discoverability.
+3. **Implement core services** inside the CLI:
+   - `DeviceProfile` definitions encapsulating remote/local file mappings and post-upload commands.
+   - `SettingsStore` to load/update the shared `settings.conf` file.
+   - `SshSession` helper to perform secure copy and remote command execution via SSH.NET.
+4. **Expose user commands** (`download`, `upload`, `reboot`) with argument parsing (`--ip`, `--password`, `--device`, optional paths) so Linux users can orchestrate the workflows from a terminal.
+5. **Update project documentation** (`README.md`) with a Linux usage section describing prerequisites (e.g., .NET SDK) and CLI examples.
+6. **Validate** by building the solution on Linux and, where possible, unit-testing the parsing logic.
+
+### Future enhancements (phase 2 – deferred)
+- Refactor the Windows Forms application to consume the new SSH helper instead of `extern.bat`, enabling a single cross-platform implementation.
+- Extend the CLI to cover advanced maintenance commands (keys management, presets, telemetry toggles) that are currently mirrored in `extern.bat`.
+- Package the CLI as a standalone binary or container image for easier distribution on Linux distributions.
+
+## Validation Strategy
+- Automated: `dotnet build` for all projects, and targeted unit tests around configuration parsing.
+- Manual: Spot-check generated/updated files (`settings.conf`, downloaded configs) and run a dry-run connection against a test host (future work when hardware is available).
+
+## Current validation status
+- ✅ Ubuntu 24.04 container with .NET SDK 8.0.119:
+  - `dotnet build OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj -c Release`
+  - `dotnet test OpenIPCConfigurator.Cli.Tests/OpenIPCConfigurator.Cli.Tests.csproj`
+  - `dotnet publish OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj -c Release -r linux-x64 --self-contained false -o publish/linux`
+
+## Risks and Mitigations
+- **SSH credential handling:** Using `SSH.NET` avoids shelling out but still requires storing passwords in memory. Ensure parameters are only logged when verbosity is requested.
+- **Incomplete command coverage:** The CLI initially covers the primary download/upload/reboot flows; documentation will clearly state the supported subset and point to future work for advanced features.
+- **Environment prerequisites:** Document the need for the .NET 8 SDK/runtime so Linux users can build or run the CLI.
+

--- a/publish-linux-cli.sh
+++ b/publish-linux-cli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT="${ROOT_DIR}/OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj"
+OUTPUT_DIR="${ROOT_DIR}/publish/linux"
+
+dotnet publish "$PROJECT" \
+  -c Release \
+  -r linux-x64 \
+  --self-contained false \
+  -o "$OUTPUT_DIR"
+
+echo "Published CLI to $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- document the current Windows-only architecture and outline the Linux support plan, including command parity details
- add a cross-platform SSH-powered CLI plus unit tests for the command-line parser with the correct SSH.NET dependency
- document Linux usage of the new CLI in the README
- add a helper script and documentation updates for publishing a linux-x64 build while recording the validated build, test, and publish commands

## Testing
- `dotnet build OpenIPCConfigurator.Cli/OpenIPCConfigurator.Cli.csproj -c Release`
- `dotnet test OpenIPCConfigurator.Cli.Tests/OpenIPCConfigurator.Cli.Tests.csproj`
- `./publish-linux-cli.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c998091a90832283100caa543cd044