### PR TITLE
Expand CLI to cover full Extern functionality

### DIFF
--- a/OpenIPCConfigurator.Cli.Tests/CommandLineParserTests.cs
+++ b/OpenIPCConfigurator.Cli.Tests/CommandLineParserTests.cs
@@ -12,15 +12,15 @@ public class CommandLineParserTests
     {
         var args = new[] { "--ip", "192.168.0.2", "--password", "secret" };
 
-        var result = CommandLineParser.TryParse(args, out var options, out var error);
+        var result = CommandLineParser.TryParse(args, out var parseResult, out var error);
 
         Assert.True(result);
         Assert.Null(error);
-        Assert.NotNull(options);
-        Assert.Equal("openipc", options!.DeviceKey);
-        Assert.Equal("192.168.0.2", options.IpAddress);
-        Assert.Equal("secret", options.Password);
-        Assert.Equal(22, options.Port);
+        Assert.NotNull(parseResult);
+        Assert.Equal("openipc", parseResult!.Options.DeviceKey);
+        Assert.Equal("192.168.0.2", parseResult.Options.IpAddress);
+        Assert.Equal("secret", parseResult.Options.Password);
+        Assert.Equal(22, parseResult.Options.Port);
     }
 
     [Fact]
@@ -41,13 +41,13 @@ public class CommandLineParserTests
             "--workdir", temp.Path
         };
 
-        var result = CommandLineParser.TryParse(args, out var options, out var error);
+        var result = CommandLineParser.TryParse(args, out var parseResult, out var error);
 
         Assert.True(result);
         Assert.Null(error);
-        Assert.NotNull(options);
-        Assert.Equal("10.0.0.5", options!.IpAddress);
-        Assert.Equal(Path.Combine(temp.Path, "settings.conf"), options.SettingsPath);
+        Assert.NotNull(parseResult);
+        Assert.Equal("10.0.0.5", parseResult!.Options.IpAddress);
+        Assert.Equal(Path.Combine(temp.Path, "settings.conf"), parseResult.Options.SettingsPath);
     }
 
     [Fact]
@@ -55,10 +55,10 @@ public class CommandLineParserTests
     {
         var args = new[] { "--ip", "192.168.0.2", "--password", "secret", "--port", "invalid" };
 
-        var result = CommandLineParser.TryParse(args, out var options, out var error);
+        var result = CommandLineParser.TryParse(args, out var parseResult, out var error);
 
         Assert.False(result);
-        Assert.Null(options);
+        Assert.Null(parseResult);
         Assert.Equal("Invalid SSH port 'invalid'.", error);
     }
 

--- a/OpenIPCConfigurator.Cli/CommandArguments.cs
+++ b/OpenIPCConfigurator.Cli/CommandArguments.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenIPCConfigurator.Cli;
+
+internal sealed class CommandArguments
+{
+    private static readonly HashSet<string> TrueValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "true",
+        "1",
+        "yes",
+        "y",
+        "on"
+    };
+
+    private static readonly HashSet<string> FalseValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "false",
+        "0",
+        "no",
+        "n",
+        "off"
+    };
+
+    private readonly IReadOnlyDictionary<string, string?> _values;
+
+    public CommandArguments(IDictionary<string, string?> values)
+    {
+        _values = new Dictionary<string, string?>(values, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public bool TryGetValue(string key, out string? value) => _values.TryGetValue(key, out value);
+
+    public bool ContainsKey(string key) => _values.ContainsKey(key);
+
+    public bool? GetBoolean(string key)
+    {
+        if (!_values.TryGetValue(key, out var raw) || raw is null)
+        {
+            return null;
+        }
+
+        if (TrueValues.Contains(raw))
+        {
+            return true;
+        }
+
+        if (FalseValues.Contains(raw))
+        {
+            return false;
+        }
+
+        return null;
+    }
+}

--- a/OpenIPCConfigurator.Cli/CommandLineParseResult.cs
+++ b/OpenIPCConfigurator.Cli/CommandLineParseResult.cs
@@ -1,0 +1,14 @@
+namespace OpenIPCConfigurator.Cli;
+
+internal sealed class CommandLineParseResult
+{
+    public CommandLineParseResult(CommandOptions options, CommandArguments arguments)
+    {
+        Options = options;
+        Arguments = arguments;
+    }
+
+    public CommandOptions Options { get; }
+
+    public CommandArguments Arguments { get; }
+}

--- a/OpenIPCConfigurator.Cli/Program.cs
+++ b/OpenIPCConfigurator.Cli/Program.cs
@@ -1,11 +1,45 @@
+
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 
 namespace OpenIPCConfigurator.Cli;
 
 internal static class Program
 {
+    private sealed record CommandHandler(string Name, string Description, Func<string[], int> Execute, string Usage);
+
+    private static readonly CommandHandler[] CommandHandlers =
+    {
+        new("download", "Download configuration files from a device.", RunDownload, "Downloads configuration files to --output (defaults to the working directory)."),
+        new("upload", "Upload configuration files to a device.", RunUpload, "Uploads configuration files from --input (defaults to the working directory)."),
+        new("reboot", "Issue a remote reboot over SSH.", RunReboot, "Triggers an immediate reboot on the target device."),
+        new("keys", "Manage FPV encryption keys.", RunKeys, "Subcommands: download --target <camera|gs>, upload --target <camera|gs>, generate."),
+        new("uart", "Toggle UART0 console access.", RunUart, "Subcommands: enable, disable."),
+        new("msp", "Manage MSP/OSD helpers.", RunMsp, "Subcommands: install-air, install-ground, remove-extra, set-osd --mode <air|ground>, configure-groundstation."),
+        new("services", "Control background services.", RunServices, "Usage: services restart --service <wifibroadcast|majestic>."),
+        new("sensors", "Synchronise sensor binaries.", RunSensors, "Subcommands: upload --file <name>, download --file <name>."),
+        new("kernel", "Synchronise kernel module payloads.", RunKernel, "Subcommands: upload --file <name>, download --file <name>."),
+        new("scripts", "Synchronise helper shell scripts.", RunScripts, "Subcommands: upload, download."),
+        new("firmware", "Perform offline firmware upgrades.", RunFirmware, "Subcommands: offline-upgrade --archive <tgz> --profile <name> [--force]."),
+        new("recording", "Toggle onboard DVR recording.", RunRecording, "Subcommands: enable, disable."),
+        new("audio", "Toggle audio capture.", RunAudio, "Subcommands: enable, disable."),
+        new("mavlink", "Configure MAVLink telemetry level.", RunMavlink, "Subcommands: set-level --level <1|2>."),
+        new("radxa", "Radxa controller helpers.", RunRadxa, "Subcommands: reset."),
+        new("camera", "Camera maintenance helpers.", RunCamera, "Subcommands: factory-reset."),
+        new("air-manager", "Install the OpenIPC air manager package.", RunAirManager, "Subcommands: install."),
+        new("pixelpilot", "Install the PixelPilot OSD suite.", RunPixelpilot, "Subcommands: install."),
+        new("alink", "Deploy alink drone binaries and profiles.", RunAlink, "Subcommands: deploy --profile <name>."),
+        new("crop", "Configure image crop presets.", RunCrop, "Subcommands: set --mode <1-5>, disable."),
+        new("bittest", "Run bitrate stability presets.", RunBittest, "Subcommands: run --mlink <value>."),
+        new("video", "Video pipeline utilities.", RunVideo, "Subcommands: fix-resolution."),
+    };
+
+    private static readonly Dictionary<string, CommandHandler> CommandLookup =
+        CommandHandlers.ToDictionary(handler => handler.Name, StringComparer.OrdinalIgnoreCase);
+
     public static int Main(string[] args)
     {
         if (args.Length == 0)
@@ -14,35 +48,37 @@ internal static class Program
             return 1;
         }
 
-        var command = args[0].ToLowerInvariant();
-        if (command is "help" or "-h" or "--help")
+        var commandName = args[0];
+        if (IsHelpCommand(commandName))
         {
-            PrintUsage();
+            if (args.Length > 1 && CommandLookup.TryGetValue(args[1], out var handler))
+            {
+                PrintCommandHelp(handler);
+            }
+            else
+            {
+                PrintUsage();
+            }
+
             return 0;
+        }
+
+        if (!CommandLookup.TryGetValue(commandName, out var command))
+        {
+            Console.Error.WriteLine($"Unknown command '{commandName}'. Use 'help' to list available commands.");
+            return 1;
         }
 
         var commandArgs = args.Skip(1).ToArray();
         if (commandArgs.Any(arg => arg is "-h" or "--help"))
         {
-            PrintUsage(command);
+            PrintCommandHelp(command);
             return 0;
-        }
-
-        if (!CommandLineParser.TryParse(commandArgs, out var options, out var error))
-        {
-            Console.Error.WriteLine(error);
-            return 1;
         }
 
         try
         {
-            return command switch
-            {
-                "download" => RunDownload(options!),
-                "upload" => RunUpload(options!),
-                "reboot" => RunReboot(options!),
-                _ => UnknownCommand(command)
-            };
+            return command.Execute(commandArgs);
         }
         catch (FileNotFoundException ex)
         {
@@ -61,27 +97,39 @@ internal static class Program
         }
     }
 
-    private static int RunDownload(CommandOptions options)
-    {
-        var profile = DeviceRegistry.GetProfile(options.DeviceKey, options.UseYaml);
-        var destination = options.DownloadDirectory;
-        Console.WriteLine($"Downloading configuration from {options.IpAddress} ({profile.Description}) to '{destination}'.");
+    private static bool IsHelpCommand(string command) => command is "help" or "-h" or "--help";
 
-        using var session = new SshSession(options.IpAddress, options.Port, options.Username, options.Password);
-        session.DownloadFiles(profile.Transfers, destination);
+    private static int RunDownload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var profile = DeviceRegistry.GetProfile(options.DeviceKey, options.UseYaml);
+        Console.WriteLine($"Downloading configuration from {options.IpAddress} ({profile.Description}) to '{options.DownloadDirectory}'.");
+
+        using var session = CreateSession(options);
+        session.DownloadFiles(profile.Transfers, options.DownloadDirectory);
 
         Console.WriteLine("Download complete.");
-
-        PersistSettings(options, profile);
+        PersistSettings(options);
         return 0;
     }
 
-    private static int RunUpload(CommandOptions options)
+    private static int RunUpload(string[] args)
     {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
         var profile = DeviceRegistry.GetProfile(options.DeviceKey, options.UseYaml);
         Console.WriteLine($"Uploading configuration from '{options.UploadDirectory}' to {options.IpAddress} ({profile.Description}).");
 
-        using var session = new SshSession(options.IpAddress, options.Port, options.Username, options.Password);
+        using var session = CreateSession(options);
         session.UploadFiles(profile.Transfers, options.UploadDirectory);
         session.ExecuteCommands(profile.PostUploadCommands);
 
@@ -92,37 +140,1226 @@ internal static class Program
         }
 
         Console.WriteLine("Upload complete.");
-
-        PersistSettings(options, profile);
+        PersistSettings(options);
         return 0;
     }
 
-    private static int RunReboot(CommandOptions options)
+    private static int RunReboot(string[] args)
     {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
         var profile = DeviceRegistry.GetProfile(options.DeviceKey, options.UseYaml);
         Console.WriteLine($"Sending reboot command to {options.IpAddress} ({profile.Description}).");
 
-        using var session = new SshSession(options.IpAddress, options.Port, options.Username, options.Password);
+        using var session = CreateSession(options);
         session.ExecuteCommands(new[] { "reboot" });
 
-        PersistSettings(options, profile);
+        PersistSettings(options);
         return 0;
     }
 
-    private static void PersistSettings(CommandOptions options, DeviceProfile profile)
+    private static int RunKeys(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The keys command requires a subcommand (download, upload, generate).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "download" => RunKeysDownload(commandArgs),
+            "upload" => RunKeysUpload(commandArgs),
+            "generate" => RunKeysGenerate(commandArgs),
+            _ => UnknownSubcommand("keys", subcommand)
+        };
+    }
+
+    private static int RunKeysDownload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var target = GetArgument(parseResult.Arguments, "target")?.ToLowerInvariant() ?? "camera";
+
+        (string RemotePath, string Description) mapping = target switch
+        {
+            "camera" or "cam" => ("/etc/drone.key", "camera"),
+            "gs" or "ground" or "groundstation" => ("/root/drone.key", "ground station"),
+            _ => default
+        };
+
+        if (mapping == default)
+        {
+            Console.Error.WriteLine("Unknown key target. Use --target camera or --target gs.");
+            return 1;
+        }
+
+        Console.WriteLine($"Downloading {mapping.Description} key from {options.IpAddress} to '{options.DownloadDirectory}'.");
+
+        using var session = CreateSession(options);
+        session.DownloadFiles(new[] { new FileTransfer(mapping.RemotePath, "drone.key") }, options.DownloadDirectory);
+
+        Console.WriteLine("Download complete.");
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunKeysUpload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var target = GetArgument(parseResult.Arguments, "target")?.ToLowerInvariant() ?? "camera";
+
+        (string RemotePath, string Description, bool CopyGsKey) mapping = target switch
+        {
+            "camera" or "cam" => ("/etc/drone.key", "camera", false),
+            "gs" or "ground" or "groundstation" => ("/etc/drone.key", "ground station", true),
+            _ => default
+        };
+
+        if (mapping == default)
+        {
+            Console.Error.WriteLine("Unknown key target. Use --target camera or --target gs.");
+            return 1;
+        }
+
+        var localKey = ResolveInputFile(options, "drone.key");
+        Console.WriteLine($"Uploading {mapping.Description} key from '{localKey}' to {options.IpAddress}.");
+
+        using var session = CreateSession(options);
+        session.UploadFile(localKey, mapping.RemotePath);
+
+        if (mapping.CopyGsKey)
+        {
+            session.ExecuteCommands(new[] { "cp /etc/drone.key /etc/gs.key" });
+        }
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunKeysGenerate(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        Console.WriteLine($"Generating fresh drone keys on {options.IpAddress}.");
+
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "wfb_keygen && cp /root/gs.key /etc/" });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunUart(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The uart command requires a subcommand (enable or disable).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "enable" => RunUartEnable(commandArgs),
+            "disable" => RunUartDisable(commandArgs),
+            _ => UnknownSubcommand("uart", subcommand)
+        };
+    }
+
+    private static int RunUartEnable(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        Console.WriteLine($"Disabling console login on UART0 for {options.IpAddress}.");
+
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[]
+        {
+            "sed -i 's/console::respawn\\/sbin\\/getty -L console 0 vt100/#console::respawn\\/sbin\\/getty -L console 0 vt100/' /etc/inittab && reboot"
+        });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunUartDisable(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        Console.WriteLine($"Enabling console login on UART0 for {options.IpAddress}.");
+
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[]
+        {
+            "sed -i 's/#console::respawn\\/sbin\\/getty -L console 0 vt100/console::respawn\\/sbin\\/getty -L console 0 vt100/' /etc/inittab && reboot"
+        });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunMsp(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The msp command requires a subcommand.");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "install-air" => RunMspInstallAir(commandArgs),
+            "install-ground" => RunMspInstallGround(commandArgs),
+            "remove-extra" => RunMspRemoveExtra(commandArgs),
+            "set-osd" => RunMspSetOsd(commandArgs),
+            "configure-groundstation" => RunMspConfigureGroundStation(commandArgs),
+            _ => UnknownSubcommand("msp", subcommand)
+        };
+    }
+
+    private static int RunMspInstallAir(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        if (!EnsureDevice(options, "openipc", "msp install-air"))
+        {
+            return 1;
+        }
+
+        using var session = CreateSession(options);
+        var wifibroadcastPath = ResolveWorkPath(options, Path.Combine("reset", "wifibroadcast"));
+        var menuPath = ResolveWorkPath(options, "vtxmenu.ini");
+
+        session.UploadFile(wifibroadcastPath, "/usr/bin/wifibroadcast");
+        session.UploadFile(menuPath, "/etc/vtxmenu.ini");
+        session.ExecuteCommands(new[] { "dos2unix /usr/bin/wifibroadcast /etc/vtxmenu.ini && wifibroadcast reset && reboot" });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunMspInstallGround(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        var wifibroadcastPath = ResolveWorkPath(options, Path.Combine("reset", "wifibroadcast_gs"));
+        var menuPath = ResolveWorkPath(options, "vtxmenu.ini");
+
+        session.ExecuteCommands(new[] { "killall wifibroadcast || true" });
+        session.UploadFile(wifibroadcastPath, "/usr/bin/wifibroadcast_gs");
+        session.UploadFile(menuPath, "/etc/vtxmenu.ini");
+        session.ExecuteCommands(new[]
+        {
+            "dos2unix /usr/bin/wifibroadcast_gs /etc/vtxmenu.ini && mv /usr/bin/wifibroadcast_gs /usr/bin/wifibroadcast && chmod +x /usr/bin/wifibroadcast && wifibroadcast reset && reboot"
+        });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunMspRemoveExtra(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "sed -i 's/sleep 5/#sleep 5/' /usr/bin/wifibroadcast && reboot" });
+        PersistSettings(options);
+        return 0;
+    }
+    private static int RunMspSetOsd(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var mode = GetArgument(parseResult.Arguments, "mode")?.ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(mode))
+        {
+            Console.Error.WriteLine("The set-osd subcommand requires --mode <air|ground>.");
+            return 1;
+        }
+
+        string command = mode switch
+        {
+            "air" => "sed -i 's/render = ground/render = air/' /config/scripts/osd && reboot",
+            "ground" or "gs" => "sed -i 's/render = air/render = ground/' /config/scripts/osd && reboot",
+            _ => string.Empty
+        };
+
+        if (string.IsNullOrEmpty(command))
+        {
+            Console.Error.WriteLine("Unknown OSD mode. Use --mode air or --mode ground.");
+            return 1;
+        }
+
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { command });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunMspConfigureGroundStation(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        const string command1 = "sed -i '/pixelpilot --osd --screen-mode $SCREEN_MODE --dvr-framerate $REC_FPS --dvr-fmp4 --dvr record_${current_date}.mp4/c\\pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE --dvr-framerate $REC_FPS --dvr-fmp4 --dvr record_${current_date}.mp4 \"&\"' /config/scripts/stream.sh";
+        const string command2 = "sed -i '/pixelpilot --osd --screen-mode $SCREEN_MODE/c\\pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE \"&\"' /config/scripts/stream.sh && reboot";
+        session.ExecuteCommands(new[] { command1, command2 });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunServices(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The services command requires a subcommand (currently only restart).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        if (subcommand != "restart")
+        {
+            return UnknownSubcommand("services", subcommand);
+        }
+
+        var commandArgs = args.Skip(1).ToArray();
+        if (!TryParseOptions(commandArgs, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var service = GetArgument(parseResult.Arguments, "service")?.ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(service))
+        {
+            Console.Error.WriteLine("The restart subcommand requires --service <wifibroadcast|majestic>.");
+            return 1;
+        }
+
+        string remoteCommand = service switch
+        {
+            "wifibroadcast" => "wifibroadcast start",
+            "majestic" => "killall -1 majestic",
+            _ => string.Empty
+        };
+
+        if (string.IsNullOrEmpty(remoteCommand))
+        {
+            Console.Error.WriteLine("Unknown service. Supported values: wifibroadcast, majestic.");
+            return 1;
+        }
+
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { remoteCommand });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunSensors(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The sensors command requires a subcommand (upload or download).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "upload" => RunSensorsUpload(commandArgs),
+            "download" => RunSensorsDownload(commandArgs),
+            _ => UnknownSubcommand("sensors", subcommand)
+        };
+    }
+
+    private static int RunSensorsUpload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var fileName = GetArgument(parseResult.Arguments, "file");
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            Console.Error.WriteLine("The sensors upload command requires --file <name>.");
+            return 1;
+        }
+
+        string localPath;
+        try
+        {
+            localPath = ResolveInputFile(options, fileName, "sensors");
+        }
+        catch (FileNotFoundException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+
+        var remotePath = $"/etc/sensors/{Path.GetFileName(localPath)}";
+        Console.WriteLine($"Uploading sensor profile '{Path.GetFileName(localPath)}' to {options.IpAddress}.");
+
+        using var session = CreateSession(options);
+        session.UploadFile(localPath, remotePath);
+        session.ExecuteCommands(new[] { $"yaml-cli -s .isp.sensorConfig {remotePath} && reboot" });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunSensorsDownload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var fileName = GetArgument(parseResult.Arguments, "file");
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            Console.Error.WriteLine("The sensors download command requires --file <name>.");
+            return 1;
+        }
+
+        var backupDir = Path.Combine(options.WorkDirectory, "backup");
+        Console.WriteLine($"Downloading sensor profile '{fileName}' from {options.IpAddress} to '{backupDir}'.");
+
+        using var session = CreateSession(options);
+        session.DownloadFiles(new[] { new FileTransfer($"/etc/sensors/{fileName}", fileName) }, backupDir);
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunKernel(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The kernel command requires a subcommand (upload or download).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "upload" => RunKernelUpload(commandArgs),
+            "download" => RunKernelDownload(commandArgs),
+            _ => UnknownSubcommand("kernel", subcommand)
+        };
+    }
+
+    private static int RunKernelUpload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var fileName = GetArgument(parseResult.Arguments, "file");
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            Console.Error.WriteLine("The kernel upload command requires --file <name>.");
+            return 1;
+        }
+
+        string localPath;
+        try
+        {
+            localPath = ResolveInputFile(options, fileName);
+        }
+        catch (FileNotFoundException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+
+        var remotePath = $"/lib/modules/4.9.84/sigmastar/{Path.GetFileName(localPath)}";
+        Console.WriteLine($"Uploading kernel module '{Path.GetFileName(localPath)}' to {options.IpAddress}.");
+
+        using var session = CreateSession(options);
+        session.UploadFile(localPath, remotePath);
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunKernelDownload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var fileName = GetArgument(parseResult.Arguments, "file");
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            Console.Error.WriteLine("The kernel download command requires --file <name>.");
+            return 1;
+        }
+
+        var backupDir = Path.Combine(options.WorkDirectory, "backup");
+        Console.WriteLine($"Downloading kernel module '{fileName}' from {options.IpAddress} to '{backupDir}'.");
+
+        using var session = CreateSession(options);
+        session.DownloadFiles(new[] { new FileTransfer($"/lib/modules/4.9.84/sigmastar/{fileName}", fileName) }, backupDir);
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunScripts(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The scripts command requires a subcommand (upload or download).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "upload" => RunScriptsUpload(commandArgs),
+            "download" => RunScriptsDownload(commandArgs),
+            _ => UnknownSubcommand("scripts", subcommand)
+        };
+    }
+
+    private static int RunScriptsUpload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var scriptFiles = Directory.Exists(options.UploadDirectory)
+            ? Directory.EnumerateFiles(options.UploadDirectory, "*.sh", SearchOption.TopDirectoryOnly).ToList()
+            : new List<string>();
+
+        if (scriptFiles.Count == 0)
+        {
+            Console.Error.WriteLine($"No .sh files found in '{options.UploadDirectory}'.");
+            return 1;
+        }
+
+        using var session = CreateSession(options);
+        foreach (var script in scriptFiles)
+        {
+            var name = Path.GetFileName(script);
+            session.UploadFile(script, $"/root/{name}");
+        }
+
+        var channelsPath = Path.Combine(options.UploadDirectory, "channels.sh");
+        if (File.Exists(channelsPath))
+        {
+            session.UploadFile(channelsPath, "/usr/bin/channels.sh");
+        }
+
+        session.ExecuteCommands(new[]
+        {
+            "rm -f /root/channels.sh",
+            "chmod +x /root/*.sh",
+            "chmod +x /usr/bin/channels.sh"
+        });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunScriptsDownload(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var transfers = new List<FileTransfer>
+        {
+            new("/usr/bin/channels.sh", "channels.sh"),
+            new("/root/816.sh", "816.sh"),
+            new("/root/1080.sh", "1080.sh"),
+            new("/root/1080b.sh", "1080b.sh"),
+            new("/root/1264.sh", "1264.sh"),
+            new("/root/3K.sh", "3K.sh"),
+            new("/root/4K.sh", "4K.sh"),
+            new("/root/1184p100.sh", "1184p100.sh"),
+            new("/root/1304p80.sh", "1304p80.sh"),
+            new("/root/1440p60.sh", "1440p60.sh"),
+            new("/root/1920p30.sh", "1920p30.sh"),
+            new("/root/1080p60.sh", "1080p60.sh"),
+            new("/root/720p120.sh", "720p120.sh"),
+            new("/root/720p100.sh", "720p100.sh"),
+            new("/root/720p90.sh", "720p90.sh"),
+            new("/root/720p60.sh", "720p60.sh"),
+            new("/root/1080p120.sh", "1080p120.sh"),
+            new("/root/1248p90.sh", "1248p90.sh"),
+            new("/root/1416p70.sh", "1416p70.sh"),
+            new("/root/kill.sh", "kill.sh")
+        };
+
+        Console.WriteLine($"Downloading helper scripts to '{options.DownloadDirectory}'.");
+        using var session = CreateSession(options);
+        session.DownloadFiles(transfers, options.DownloadDirectory);
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunFirmware(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The firmware command requires a subcommand (offline-upgrade).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "offline-upgrade" => RunFirmwareOfflineUpgrade(commandArgs),
+            _ => UnknownSubcommand("firmware", subcommand)
+        };
+    }
+
+    private static int RunFirmwareOfflineUpgrade(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var archiveOption = GetArgument(parseResult.Arguments, "archive") ?? GetArgument(parseResult.Arguments, "package");
+        var profile = GetArgument(parseResult.Arguments, "profile");
+        var force = parseResult.Arguments.GetBoolean("force") ?? false;
+
+        if (string.IsNullOrWhiteSpace(archiveOption) || string.IsNullOrWhiteSpace(profile))
+        {
+            Console.Error.WriteLine("offline-upgrade requires --archive <tgz> and --profile <name>.");
+            return 1;
+        }
+
+        var archivePath = archiveOption.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase)
+            ? archiveOption
+            : archiveOption + ".tgz";
+
+        string localArchive;
+        try
+        {
+            localArchive = ResolveInputFile(options, archivePath);
+        }
+        catch (FileNotFoundException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+
+        var fileName = Path.GetFileName(localArchive);
+        var remoteArchive = $"/tmp/{fileName}";
+        var remoteTar = $"/tmp/{Path.GetFileNameWithoutExtension(fileName)}.tar";
+
+        Console.WriteLine($"Uploading firmware package '{fileName}' to {options.IpAddress}.");
+        using var session = CreateSession(options);
+        session.UploadFile(localArchive, remoteArchive);
+
+        var upgradeCommand = $"gzip -d {remoteArchive} && tar -xvf {remoteTar} -C /tmp && sysupgrade --kernel=/tmp/uImage.{profile} --rootfs=/tmp/rootfs.squashfs.{profile} -n" + (force ? " -f" : string.Empty);
+        session.ExecuteCommands(new[] { upgradeCommand });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunRecording(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The recording command requires a subcommand (enable or disable).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "enable" => RunRecordingEnable(commandArgs),
+            "disable" => RunRecordingDisable(commandArgs),
+            _ => UnknownSubcommand("recording", subcommand)
+        };
+    }
+
+    private static int RunRecordingEnable(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "yaml-cli -s .records.enabled true && reboot" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunRecordingDisable(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "yaml-cli -s .records.enabled false && reboot" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunAudio(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The audio command requires a subcommand (enable or disable).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "enable" => RunAudioEnable(commandArgs),
+            "disable" => RunAudioDisable(commandArgs),
+            _ => UnknownSubcommand("audio", subcommand)
+        };
+    }
+
+    private static int RunAudioEnable(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "yaml-cli -s .audio.enabled true && reboot" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunAudioDisable(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "yaml-cli -s .audio.enabled false && reboot" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunMavlink(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The mavlink command requires a subcommand (set-level).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "set-level" => RunMavlinkSetLevel(commandArgs),
+            _ => UnknownSubcommand("mavlink", subcommand)
+        };
+    }
+
+    private static int RunMavlinkSetLevel(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var levelValue = GetArgument(parseResult.Arguments, "level");
+        if (string.IsNullOrWhiteSpace(levelValue) || !int.TryParse(levelValue, out var level) || (level != 1 && level != 2))
+        {
+            Console.Error.WriteLine("set-level requires --level 1 or --level 2.");
+            return 1;
+        }
+
+        string command1 = level switch
+        {
+            2 => "sed -i '/pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE --dvr-framerate $REC_FPS --dvr-fmp4 --dvr record_${current_date}.mp4 \"&\"/c\\pixelpilot --osd --screen-mode $SCREEN_MODE --dvr-framerate $REC_FPS --dvr-fmp4 --dvr record_${current_date}.mp4 --osd-telem-lvl 2 \"&\"' /config/scripts/stream.sh",
+            _ => "sed -i '/pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE --dvr-framerate $REC_FPS --dvr-fmp4 --dvr record_${current_date}.mp4 \"&\"/c\\pixelpilot --osd --screen-mode $SCREEN_MODE --dvr-framerate $REC_FPS --dvr-fmp4 --dvr record_${current_date}.mp4 --osd-telem-lvl 1 \"&\"' /config/scripts/stream.sh"
+        };
+
+        string command2 = level switch
+        {
+            2 => "sed -i '/pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE \"&\"/c\\pixelpilot --osd --screen-mode $SCREEN_MODE --osd-telem-lvl 2 \"&\"' /config/scripts/stream.sh && reboot",
+            _ => "sed -i '/pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE \"&\"/c\\pixelpilot --osd --screen-mode $SCREEN_MODE --osd-telem-lvl 1 \"&\"' /config/scripts/stream.sh && reboot"
+        };
+
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { command1, command2 });
+        PersistSettings(options);
+        return 0;
+    }
+    private static int RunRadxa(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The radxa command requires a subcommand (reset).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "reset" => RunRadxaReset(commandArgs),
+            _ => UnknownSubcommand("radxa", subcommand)
+        };
+    }
+
+    private static int RunRadxaReset(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        if (!EnsureDevice(options, "radxa", "radxa reset"))
+        {
+            return 1;
+        }
+
+        using var session = CreateSession(options);
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "wifibroadcast.cfg")), "/etc/wifibroadcast.cfg");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "wfb.conf")), "/etc/modprobe.d/wfb.conf");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "wifibroadcast")), "/etc/default/wifibroadcast");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "stream.sh")), "/config/scripts/stream.sh");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "osd")), "/config/scripts/osd");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "osd.json")), "/config/scripts/osd.json");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "rec-fps")), "/config/scripts/rec-fps");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "screen-mode")), "/config/scripts/screen-mode");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "alink_gs.conf")), "/config/alink_gs.conf");
+
+        session.ExecuteCommands(new[]
+        {
+            "dos2unix /etc/wifibroadcast.cfg /etc/modprobe.d/wfb.conf /etc/default/wifibroadcast /config/scripts/screen-mode /config/scripts/osd /config/scripts/osd.json /config/scripts/stream.sh /config/scripts/rec-fps /config/alink_gs.conf && reboot"
+        });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunCamera(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The camera command requires a subcommand (factory-reset).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "factory-reset" => RunCameraFactoryReset(commandArgs),
+            _ => UnknownSubcommand("camera", subcommand)
+        };
+    }
+
+    private static int RunCameraFactoryReset(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "firstboot" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunAirManager(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The air-manager command requires a subcommand (install).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "install" => RunAirManagerInstall(commandArgs),
+            _ => UnknownSubcommand("air-manager", subcommand)
+        };
+    }
+
+    private static int RunAirManagerInstall(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var archivePath = ResolveWorkPath(options, "OpenIPC-air_manager.tar");
+        using var session = CreateSession(options);
+        session.UploadFile(archivePath, "/OpenIPC-air_manager.tar");
+        session.ExecuteCommands(new[] { "tar -xvf /OpenIPC-air_manager.tar && cd /root/OpenIPC-air_manager/ && chmod +x install.sh && ./install.sh 10.5.0.10" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunPixelpilot(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The pixelpilot command requires a subcommand (install).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "install" => RunPixelpilotInstall(commandArgs),
+            _ => UnknownSubcommand("pixelpilot", subcommand)
+        };
+    }
+
+    private static int RunPixelpilotInstall(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var artifactPath = ResolveWorkPath(options, "artifact.zip");
+        Console.WriteLine("Extracting PixelPilot artifacts...");
+        ZipFile.ExtractToDirectory(artifactPath, options.WorkDirectory, overwriteFiles: true);
+
+        var pixelpilotBin = ResolveWorkPath(options, "pixelpilot");
+        var menuScript = ResolveWorkPath(options, "gsmenu.sh");
+        var configJson = ResolveWorkPath(options, "config_osd.json");
+
+        using var session = CreateSession(options);
+        const string prepCommand = "systemctl stop openipc && awk 'NR==2 {$0=\"sed -i '\''s/\\r//'\'' /config/setup.txt \"&\"\"} {print }' /config/scripts/stream.sh > /config/scripts/stream2.sh && rm /config/scripts/stream.sh && mv /config/scripts/stream2.sh /config/scripts/stream.sh";
+        session.ExecuteCommands(new[] { prepCommand });
+        session.UploadFile(pixelpilotBin, "/usr/local/bin/pixelpilot");
+        session.UploadFile(menuScript, "/usr/local/bin/gsmenu.sh");
+        session.UploadFile(pixelpilotBin, "/usr/local/etc/pixelpilot/pixelpilot");
+        session.UploadFile(configJson, "/usr/local/etc/pixelpilot/config_osd.json");
+        session.ExecuteCommands(new[] { "reboot" });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    }
+
+    private static int RunAlink(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The alink command requires a subcommand (deploy).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "deploy" => RunAlinkDeploy(commandArgs),
+            _ => UnknownSubcommand("alink", subcommand)
+        };
+    }
+
+    private static int RunAlinkDeploy(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var profileName = GetArgument(parseResult.Arguments, "profile");
+        if (string.IsNullOrWhiteSpace(profileName))
+        {
+            Console.Error.WriteLine("The alink deploy command requires --profile <name>.");
+            return 1;
+        }
+
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "killall alink_drone || true" });
+        session.UploadFile(ResolveWorkPath(options, "alink_drone"), "/usr/bin/alink_drone");
+        session.UploadFile(ResolveWorkPath(options, "yaml-cli-multi"), "/usr/bin/yaml-cli-multi");
+        session.UploadFile(ResolveWorkPath(options, "wlan_adapters.yaml"), "/etc/wlan_adapters.yaml");
+        session.UploadFile(ResolveWorkPath(options, "alink.conf"), "/etc/alink.conf");
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("txprofiles", $"{profileName}.conf")), $"/etc/{profileName}.conf");
+        session.ExecuteCommands(new[]
+        {
+            $"mv /etc/{profileName}.conf /etc/txprofiles.conf && dos2unix /etc/alink.conf /etc/wlan_adapters.yaml /etc/txprofiles.conf && chmod +x /usr/bin/alink_drone && chmod +x /usr/bin/yaml-cli-multi && reboot"
+        });
+
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunCrop(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The crop command requires a subcommand (set or disable).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "set" => RunCropSet(commandArgs),
+            "disable" => RunCropDisable(commandArgs),
+            _ => UnknownSubcommand("crop", subcommand)
+        };
+    }
+
+    private static int RunCropSet(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var modeValue = GetArgument(parseResult.Arguments, "mode");
+        if (string.IsNullOrWhiteSpace(modeValue) || !int.TryParse(modeValue, out var mode) || mode < 1 || mode > 5)
+        {
+            Console.Error.WriteLine("The crop set command requires --mode between 1 and 5.");
+            return 1;
+        }
+
+        var commands = new Dictionary<int, string>
+        {
+            [1] = "sed -i '/echo setprecrop/c\\echo setprecrop 0 0 904 0 2436 1828 \">\" /proc/mi_modules/mi_vpe/mi_vpe0' /etc/rc.local",
+            [2] = "sed -i '/echo setprecrop/c\\echo setprecrop 0 0 904 0 2560 1920 \">\" /proc/mi_modules/mi_vpe/mi_vpe0' /etc/rc.local",
+            [3] = "sed -i '/echo setprecrop/c\\echo setprecrop 0 0 904 0 1440 1080 \">\" /proc/mi_modules/mi_vpe/mi_vpe0' /etc/rc.local",
+            [4] = "sed -i '/echo setprecrop/c\\echo setprecrop 0 0 240 0 1440 1080 \">\" /proc/mi_modules/mi_vpe/mi_vpe0' /etc/rc.local",
+            [5] = "sed -i '/echo setprecrop/c\\echo setprecrop 0 0 904 0 1440 1080 \">\" /proc/mi_modules/mi_vpe/mi_vpe0' /etc/rc.local"
+        };
+
+        using var session = CreateSession(options);
+        session.UploadFile(ResolveWorkPath(options, Path.Combine("reset", "rc.local")), "/etc/rc.local");
+        session.ExecuteCommands(new[] { "dos2unix /etc/rc.local" });
+        session.ExecuteCommands(new[] { commands[mode] });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunCropDisable(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "sed -i '/sleep 0.5/d' /etc/rc.local && sed -i '/echo setprecrop*/d' /etc/rc.local" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunBittest(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The bittest command requires a subcommand (run).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "run" => RunBittestRun(commandArgs),
+            _ => UnknownSubcommand("bittest", subcommand)
+        };
+    }
+
+    private static int RunBittestRun(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        var mlinkValue = GetArgument(parseResult.Arguments, "mlink");
+        if (string.IsNullOrWhiteSpace(mlinkValue))
+        {
+            Console.Error.WriteLine("The bittest run command requires --mlink <value>.");
+            return 1;
+        }
+
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { $"yaml-cli -s .fpv.noiseLevel 0 && wifibroadcast cli -s .wireless.mlink {mlinkValue} && wifibroadcast start" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static int RunVideo(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("The video command requires a subcommand (fix-resolution).");
+            return 1;
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var commandArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "fix-resolution" => RunVideoFixResolution(commandArgs),
+            _ => UnknownSubcommand("video", subcommand)
+        };
+    }
+
+    private static int RunVideoFixResolution(string[] args)
+    {
+        if (!TryParseOptions(args, out var parseResult))
+        {
+            return 1;
+        }
+
+        var options = parseResult!.Options;
+        using var session = CreateSession(options);
+        session.ExecuteCommands(new[] { "yaml-cli -s .video0.size 1920x1080" });
+        PersistSettings(options);
+        return 0;
+    }
+
+    private static bool TryParseOptions(string[] args, out CommandLineParseResult? result)
+    {
+        if (!CommandLineParser.TryParse(args, out result, out var error))
+        {
+            Console.Error.WriteLine(error);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void PersistSettings(CommandOptions options)
     {
         if (!options.RememberSettings)
         {
             return;
         }
 
+        var profile = DeviceRegistry.GetProfile(options.DeviceKey, options.UseYaml);
         var store = SettingsStore.Load(options.SettingsPath);
         store.SetAddress(profile.Key, options.IpAddress);
         store.Save();
         Console.WriteLine($"Updated '{options.SettingsPath}' with the last-used {profile.Key} address.");
     }
 
-    private static void PrintUsage(string? command = null)
+    private static SshSession CreateSession(CommandOptions options) => new(options.IpAddress, options.Port, options.Username, options.Password);
+
+    private static void PrintUsage()
     {
         Console.WriteLine("OpenIPC Configurator CLI");
         Console.WriteLine();
@@ -130,24 +1367,41 @@ internal static class Program
         Console.WriteLine("  configurator-cli <command> [options]");
         Console.WriteLine();
         Console.WriteLine("Commands:");
-        Console.WriteLine("  download   Download configuration files from a device.");
-        Console.WriteLine("  upload     Upload configuration files to a device.");
-        Console.WriteLine("  reboot     Issue a reboot over SSH.");
-        Console.WriteLine("  help       Show this help message.");
+        foreach (var handler in CommandHandlers)
+        {
+            Console.WriteLine($"  {handler.Name,-15}{handler.Description}");
+        }
+
+        Console.WriteLine("  help           Show this help message.");
         Console.WriteLine();
+        PrintCommonOptions();
+        Console.WriteLine("Use 'configurator-cli help <command>' to view command-specific details.");
+    }
+
+    private static void PrintCommandHelp(CommandHandler handler)
+    {
+        Console.WriteLine($"Command: {handler.Name}");
+        Console.WriteLine(handler.Description);
+        Console.WriteLine();
+        PrintCommonOptions();
+        Console.WriteLine(handler.Usage);
+    }
+
+    private static void PrintCommonOptions()
+    {
         Console.WriteLine("Common options:");
-        Console.WriteLine("  --ip, -i <address>          Device IP address (falls back to settings.conf entry).\n" +
-                          "  --password, -p <password>   SSH password (required).\n" +
-                          "  --device, -d <name>         Device type (default: openipc).\n" +
-                          "  --username, -u <name>       SSH username (default: root).\n" +
-                          "  --port, -P <number>         SSH port (default: 22).\n" +
-                          "  --workdir, -w <path>        Working directory (default: current).\n" +
-                          "  --input, -I <path>          Override upload source directory.\n" +
-                          "  --output, -o <path>         Override download destination directory.\n" +
-                          "  --settings <path>           Path to settings.conf (default: <workdir>/settings.conf).\n" +
-                          "  --yaml                      Use the wfb.yaml profile for OpenIPC cameras.\n" +
-                          "  --reboot, -r                Reboot the device after uploading.\n" +
-                          "  --no-remember               Do not update settings.conf after completion.");
+        Console.WriteLine("  --ip, -i <address>          Device IP address (falls back to settings.conf entry).");
+        Console.WriteLine("  --password, -p <password>   SSH password (required).");
+        Console.WriteLine("  --device, -d <name>         Device type (default: openipc).");
+        Console.WriteLine("  --username, -u <name>       SSH username (default: root).");
+        Console.WriteLine("  --port, -P <number>         SSH port (default: 22).");
+        Console.WriteLine("  --workdir, -w <path>        Working directory (default: current).");
+        Console.WriteLine("  --input, -I <path>          Override upload source directory.");
+        Console.WriteLine("  --output, -o <path>         Override download destination directory.");
+        Console.WriteLine("  --settings <path>           Path to settings.conf (default: <workdir>/settings.conf).");
+        Console.WriteLine("  --yaml                      Use the wfb.yaml profile for OpenIPC cameras.");
+        Console.WriteLine("  --reboot, -r                Reboot the device after uploading configuration files.");
+        Console.WriteLine("  --no-remember               Do not update settings.conf after completion.");
         Console.WriteLine();
         Console.WriteLine("Supported devices:");
         foreach (var device in DeviceRegistry.GetSupportedDevices())
@@ -155,17 +1409,74 @@ internal static class Program
             Console.WriteLine($"  {device.Key,-8} {device.Description}");
         }
         Console.WriteLine();
-
-        if (!string.IsNullOrEmpty(command))
-        {
-            Console.WriteLine($"Command '{command}' accepts the options listed above.");
-            Console.WriteLine();
-        }
     }
 
-    private static int UnknownCommand(string command)
+    private static int UnknownSubcommand(string command, string subcommand)
     {
-        Console.Error.WriteLine($"Unknown command '{command}'. Use 'help' to list available commands.");
+        Console.Error.WriteLine($"Unknown subcommand '{subcommand}' for '{command}'. Use 'configurator-cli help {command}' for usage details.");
         return 1;
+    }
+
+    private static string? GetArgument(CommandArguments arguments, string key)
+    {
+        return arguments.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value
+            : null;
+    }
+
+    private static bool EnsureDevice(CommandOptions options, string expectedKey, string commandName)
+    {
+        if (!string.Equals(options.DeviceKey, expectedKey, StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine($"The '{commandName}' command requires --device {expectedKey}.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string ResolveInputFile(CommandOptions options, string file, params string[] fallbackDirectories)
+    {
+        if (string.IsNullOrWhiteSpace(file))
+        {
+            throw new ArgumentException("File name cannot be empty.", nameof(file));
+        }
+
+        var searchPaths = new List<string>();
+        if (Path.IsPathRooted(file))
+        {
+            searchPaths.Add(file);
+        }
+        else
+        {
+            searchPaths.Add(Path.Combine(options.UploadDirectory, file));
+            searchPaths.Add(Path.Combine(options.WorkDirectory, file));
+            foreach (var folder in fallbackDirectories)
+            {
+                searchPaths.Add(Path.Combine(options.WorkDirectory, folder, file));
+            }
+        }
+
+        foreach (var candidate in searchPaths)
+        {
+            if (File.Exists(candidate))
+            {
+                return Path.GetFullPath(candidate);
+            }
+        }
+
+        var checkedPaths = string.Join(", ", searchPaths.Select(path => Path.GetDirectoryName(path) ?? path).Distinct());
+        throw new FileNotFoundException($"Required file '{file}' not found. Checked: {checkedPaths}.", searchPaths[0]);
+    }
+
+    private static string ResolveWorkPath(CommandOptions options, string relativePath)
+    {
+        var path = Path.Combine(options.WorkDirectory, relativePath);
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Required file '{relativePath}' not found in '{options.WorkDirectory}'.", path);
+        }
+
+        return Path.GetFullPath(path);
     }
 }

--- a/OpenIPCConfigurator.Cli/SshSession.cs
+++ b/OpenIPCConfigurator.Cli/SshSession.cs
@@ -57,6 +57,19 @@ internal sealed class SshSession : IDisposable
         }
     }
 
+    public void UploadFile(string localPath, string remotePath)
+    {
+        Connect();
+
+        if (!File.Exists(localPath))
+        {
+            throw new FileNotFoundException($"Required file '{localPath}' not found.", localPath);
+        }
+
+        using var localStream = File.OpenRead(localPath);
+        _scpClient.Upload(localStream, remotePath);
+    }
+
     public void ExecuteCommands(IEnumerable<string> commands)
     {
         Connect();

--- a/README.md
+++ b/README.md
@@ -76,4 +76,19 @@ Key flags:
 - `--yaml` – switch the OpenIPC profile to the YAML-based wireless stack (`wfb.yaml`).
 - `--no-remember` – skip updating `settings.conf` with the last-used IP address.
 
+### Additional commands
+
+The CLI mirrors the legacy `Extern.bat` workflow, exposing commands for maintenance tasks beyond configuration sync. Highlights:
+
+- `keys download|upload|generate` – manage drone key material for the camera or ground station.
+- `uart enable|disable` – toggle console login over UART0.
+- `msp` – install MSP extras, adjust OSD profiles, or configure ground-station telemetry presets.
+- `services restart` – restart `wifibroadcast` or `majestic` without a full reboot.
+- `sensors`, `kernel`, `scripts` – transfer binary blobs and helper scripts with automatic backup support.
+- `firmware offline-upgrade` – push a `.tgz` firmware package and trigger `sysupgrade` (with optional `--force`).
+- `recording`, `audio`, `mavlink`, `bittest`, `video` – tweak runtime features such as DVR recording, audio, telemetry level, or video sizing.
+- `radxa reset`, `camera factory-reset`, `air-manager install`, `pixelpilot install`, `alink deploy` – perform higher-level platform maintenance, including Radxa resets and PixelPilot provisioning.
+
+Run `dotnet run --project OpenIPCConfigurator.Cli -- help <command>` for the full option set on any subcommand.
+
 For full option details run `dotnet run --project OpenIPCConfigurator.Cli -- help`.

--- a/docs/linux-support-plan.md
+++ b/docs/linux-support-plan.md
@@ -31,7 +31,14 @@ The legacy `Extern.bat` script orchestrates PuTTY utilities for a wide range of 
 | `dlvrx`, `ulvrx(r)`    | Ground-station config sync                           | ✅ `--device nvr` profile      | Same transfers and `dos2unix` calls. |
 | `dlwfbng`, `ulwfbng(r)`| Radxa controller config sync                         | ✅ `--device radxa` profile    | Upload ensures required files exist. |
 | `rb`                   | Remote reboot                                        | ✅ dedicated `reboot` command  | Aligns with GUI reboot button flow. |
-| Remaining verbs (keys, UART, firmware, extras, etc.) | Maintenance & advanced tweaks | ⏳ Future iterations | Documented under "Future enhancements" backlog. |
+| `keysdl*`, `keysul*`, `keysgen` | Drone key management | ✅ `keys` command family | Supports ground station and camera targets with settings persistence. |
+| `UART0on`, `UART0off` | UART console toggle | ✅ `uart enable/disable` | Issues reboot automatically to apply changes. |
+| `mspextra`, `mspgsextra`, `remmspextra`, `msposd*`, `mspgs`, `mavgs*` | MSP extras and OSD presets | ✅ `msp` subcommands | Installs helpers, adjusts telemetry level, and reboots when required. |
+| `rswfb`, `rsmaj` | Service restarts | ✅ `services restart` | Provides fast restart without reboot. |
+| `binup`, `bindl`, `koup`, `kodl`, `shup`, `shdl` | Sensor, kernel, and script transfer | ✅ `sensors`, `kernel`, `scripts` commands | Uploads/downloads with backup handling. |
+| `offlinefw`, `offlinefwf` | Firmware upgrades | ✅ `firmware offline-upgrade` | Adds `--force` flag parity. |
+| `onboardrecon*`, `audio*`, `bittest`, `resfix` | Runtime toggles | ✅ `recording`, `audio`, `bittest`, `video` commands | Uses yaml-cli to apply settings. |
+| `resetradxa`, `resetcam`, `airman`, `pixelpilot`, `alink`, `box`, `wide` | Platform maintenance | ✅ dedicated commands (`radxa`, `camera`, `air-manager`, `pixelpilot`, `alink`, `crop`) | Leverages repository assets under `reset/` and `txprofiles/`. |
 
 ### Implementation plan (phase 1 – executed now)
 1. **Create documentation** (this file) to capture the current architecture and Linux-support strategy.
@@ -46,7 +53,6 @@ The legacy `Extern.bat` script orchestrates PuTTY utilities for a wide range of 
 
 ### Future enhancements (phase 2 – deferred)
 - Refactor the Windows Forms application to consume the new SSH helper instead of `extern.bat`, enabling a single cross-platform implementation.
-- Extend the CLI to cover advanced maintenance commands (keys management, presets, telemetry toggles) that are currently mirrored in `extern.bat`.
 - Package the CLI as a standalone binary or container image for easier distribution on Linux distributions.
 
 ## Validation Strategy


### PR DESCRIPTION
## Summary
- add reusable command argument parsing helpers and extend the CLI program to expose every Extern.bat verb, including key management, MSP extras, firmware upgrades, and platform maintenance
- enrich the SSH session helper with single-file upload support leveraged by the new commands
- document the expanded Linux workflow in the README and update the Linux plan with the completed parity items

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68caf1e76c508322a526583998a6ef70